### PR TITLE
Reduce permissions granted to extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,9 @@
     "persistent": false
   },
   "options_page": "options.html",
-  "permissions": ["storage", "tabs", "contextMenus", "http://*/*", "https://*/*", "ftp://*/*"]
+  "permissions": [
+    "storage",
+    "tabs",
+    "contextMenus"
+  ]
 }


### PR DESCRIPTION
Reduce the permissions given to this extension so that instead of:
`Read and change all your data on the websites you visit`

The extension asks for:
`Read your browsing history`

This appears to be the best we can do, given that the extension needs the "tabs" permission in order to reload tabs.