### PR TITLE
ENH: Reload options on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This Google Chrome extension reloads or refreshes all tabs.
    don't like it.
  - You can customize the preference whether to refresh all windows, pinned tabs
    or just the current one, as well as all tabs to the right or left.
+ - You can have it reload tabs on startup.
 
 ## Download
 

--- a/js/options.js
+++ b/js/options.js
@@ -38,10 +38,11 @@ function onSave() {
     'reloadUnpinnedOnly': $('reloadUnpinnedOnly').checked,
     'reloadAllLeft': $('reloadAllLeft').checked,
     'reloadAllRight': $('reloadAllRight').checked,
+    'reloadStartup': $('reloadStartup').value
   };
 
   chrome.storage.sync.set(settingsToSave, () => {
-    
+
     // Update status to let user know options were saved.
     var info = $('info-message')
     info.style.display = 'inline'
@@ -63,6 +64,7 @@ function onRestore() {
     'reloadUnpinnedOnly',
     'reloadAllLeft',
     'reloadAllRight',
+    'reloadStartup',
     'version'
   ]
 
@@ -74,11 +76,12 @@ function onRestore() {
     $('reloadUnpinnedOnly').checked = settings.reloadUnpinnedOnly == true
     $('reloadAllLeft').checked = settings.reloadAllLeft == true
     $('reloadAllRight').checked = settings.reloadAllRight == true
+    $('reloadStartup').value = (typeof settings.reloadStartup == 'undefined') ? 'none' : settings.reloadStartup
   })
 
   chrome.commands.getAll(callback => {
     $('keyboardShortcut').innerText = callback[0].shortcut || 'Not Set'
-  }) 
+  })
 }
 
 function onKeyboardShortcut(e) {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Reload All Tabs",
   "version": "4.2.0",
   "manifest_version": 2,
-  "description": "Reload All tabs using keyboard shortcut(alt + shift + r), context menu, or browser action button.",
+  "description": "Reload All tabs using keyboard shortcut(alt + shift + r), context menu, browser action button, or startup.",
   "icons": {
     "16": "img/icon16.png",
     "48": "img/icon48.png",

--- a/options.html
+++ b/options.html
@@ -56,9 +56,21 @@
       </div>
     </div>
     <div class="extension-template">
+      <div class="extension-header">Startup</div>
+      <div class="extension-options">
+        <p>Reload the following tabs on startup:</p>
+        <select id="reloadStartup">
+          <option value="all">All tabs</option>
+          <option value="pinned">Pinned tabs</option>
+          <option value="unpinned">Unpinned tabs</option>
+          <option value="none">None</option>
+        </select>
+      </div>
+    </div>
+    <div class="extension-template">
       <div class="extension-header">Keyboard Shortcut Options</div>
       <div class="extension-options">
-        <p>To setup the keyboard shortcut or change it, please visit the shortcuts page in Chrome: 
+        <p>To setup the keyboard shortcut or change it, please visit the shortcuts page in Chrome:
           <span id="keyboardShortcutUpdate">chrome://extensions/shortcuts</span></p>
         <img src="/img/keyboard-shortcut.png" alt="Reload All Tabs Keyboard Shortcut" />
         <dl>


### PR DESCRIPTION
Closes #22.

I wanted to have my pinned tabs reload on startup because for some reason my Slack pinned tabs don't work until they are loaded (maybe some lazy loading issue in Chrome? no idea...).

@DenBLR feel free to try it. If you `git clone` you can then install in "Developer mode" on the Chrome extensions do the "Load unpacked" on the `reload-all-tabs-extension` folder.

This is my first Javascript PR (mostly a Python person) so feel free to nitpick it to deal, I'm all ears!